### PR TITLE
Preference support

### DIFF
--- a/api/src/main/java/io/sweers/barber/Barber.java
+++ b/api/src/main/java/io/sweers/barber/Barber.java
@@ -2,7 +2,6 @@ package io.sweers.barber;
 
 import android.util.AttributeSet;
 import android.util.Log;
-import android.view.View;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -10,7 +9,7 @@ import java.util.Map;
 /**
  * Entry point for applications.
  * <p>
- * Use one of the {@link #style(android.view.View, android.util.AttributeSet, int[])} variants to
+ * Use one of the {@link #style(java.lang.Object, android.util.AttributeSet, int[])} variants to
  * style your custom views.
  */
 public class Barber {
@@ -19,24 +18,24 @@ public class Barber {
     public static final String ANDROID_PREFIX = "android.";
     public static final String JAVA_PREFIX = "java.";
     private static final String TAG = "Barber";
-    private static final IBarbershop<View> NO_OP = null;
+    private static final IBarbershop<Object> NO_OP = null;
     private static boolean debug = false;
-    private static final Map<Class<?>, IBarbershop<View>> BARBERSHOPS = new LinkedHashMap<>();
+    private static final Map<Class<?>, IBarbershop<Object>> BARBERSHOPS = new LinkedHashMap<>();
 
-    public static void style(View target, AttributeSet set, int[] attrs) {
+    public static void style(Object target, AttributeSet set, int[] attrs) {
         style(target, set, attrs, 0);
     }
 
-    public static void style(View target, AttributeSet set, int[] attrs, int defStyleAttr) {
+    public static void style(Object target, AttributeSet set, int[] attrs, int defStyleAttr) {
         style(target, set, attrs, defStyleAttr, 0);
     }
 
-    public static void style(View target, AttributeSet set, int[] attrs, int defStyleAttr, int defStyleRes) {
+    public static void style(Object target, AttributeSet set, int[] attrs, int defStyleAttr, int defStyleRes) {
         Class<?> targetClass = target.getClass();
         if (debug) {
             Log.d(TAG, "Looking up barbershop for " + targetClass.getName());
         }
-        IBarbershop<View> barbershop = findBarbershopForClass(targetClass);
+        IBarbershop<Object> barbershop = findBarbershopForClass(targetClass);
         if (barbershop != NO_OP) {
             barbershop.style(target, set, attrs, defStyleAttr, defStyleRes);
         }
@@ -48,8 +47,8 @@ public class Barber {
      * @param cls Source class to find a matching $$Barbershop class for
      * @return $$Barbershop class instance
      */
-    private static IBarbershop<View> findBarbershopForClass(Class<?> cls) {
-        IBarbershop<View> barbershop = BARBERSHOPS.get(cls);
+    private static IBarbershop<Object> findBarbershopForClass(Class<?> cls) {
+        IBarbershop<Object> barbershop = BARBERSHOPS.get(cls);
         if (barbershop != null) {
             if (debug) Log.d(TAG, "HIT: Cached in barbershop map.");
             return barbershop;
@@ -65,7 +64,7 @@ public class Barber {
         try {
             Class<?> barbershopClass = Class.forName(clsName + SUFFIX);
             //noinspection unchecked
-            barbershop = (IBarbershop<View>) barbershopClass.newInstance();
+            barbershop = (IBarbershop<Object>) barbershopClass.newInstance();
             if (debug) {
                 Log.d(TAG, "HIT: Class loaded barbershop class.");
             }

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 ext {
     Properties props = new Properties()
-    props.load(new FileInputStream("private.props"))
+    props.load(new FileInputStream(file("private.props")))
     siteUrl = 'https://github.com/hzsweers/barber'
     gitUrl = 'https://github.com/hzsweers/barber.git'
     bintrayUser = 'pandanomic'

--- a/sample/src/androidTest/java/io/sweers/barber/sample/PreferenceTest.java
+++ b/sample/src/androidTest/java/io/sweers/barber/sample/PreferenceTest.java
@@ -1,0 +1,39 @@
+package io.sweers.barber.sample;
+
+import android.content.Intent;
+import android.content.res.Resources;
+import android.test.ActivityUnitTestCase;
+import android.test.suitebuilder.annotation.SmallTest;
+
+import io.sweers.barber.sample.testing.TestPreferencesActivity;
+
+/**
+ * Preferences can be styled too!
+ */
+public class PreferenceTest extends ActivityUnitTestCase<TestPreferencesActivity> {
+
+    private TestPreferencesActivity testPreferencesActivity;
+    private Resources resources;
+
+    public PreferenceTest() {
+        super(TestPreferencesActivity.class);
+    }
+
+    public PreferenceTest(Class<TestPreferencesActivity> activityClass) {
+        super(activityClass);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        startActivity(new Intent(getInstrumentation().getTargetContext(), TestPreferencesActivity.class), null, null);
+        testPreferencesActivity = getActivity();
+        resources = testPreferencesActivity.getResources();
+    }
+
+    @SmallTest
+    public void testAttributes() {
+        assertEquals(resources.getColor(android.R.color.holo_red_dark), testPreferencesActivity.customPreference.titleColor);
+        assertEquals(resources.getColor(android.R.color.holo_blue_dark), testPreferencesActivity.customPreference.summaryColor);
+    }
+}

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -17,6 +17,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".testing.TestPreferencesActivity"
+            android:label="Preferences Test"
+            android:screenOrientation="portrait"
+            />
     </application>
 
 </manifest>

--- a/sample/src/main/java/io/sweers/barber/sample/testing/CustomPreference.java
+++ b/sample/src/main/java/io/sweers/barber/sample/testing/CustomPreference.java
@@ -1,0 +1,59 @@
+package io.sweers.barber.sample.testing;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.preference.Preference;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.TextView;
+
+import io.sweers.barber.Barber;
+import io.sweers.barber.Kind;
+import io.sweers.barber.StyledAttr;
+import io.sweers.barber.sample.R;
+
+/**
+* Styled preference
+*/
+public class CustomPreference extends Preference {
+
+    @StyledAttr(value = R.styleable.TestPreference_prefTitleColor, kind = Kind.COLOR)
+    public int titleColor = -1;
+
+    @StyledAttr(value = R.styleable.TestPreference_prefSummaryColor, kind = Kind.COLOR)
+    public int summaryColor = -1;
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public CustomPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        Barber.style(this, attrs, R.styleable.TestPreference, defStyleAttr, defStyleRes);
+    }
+
+    public CustomPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        Barber.style(this, attrs, R.styleable.TestPreference, defStyleAttr);
+    }
+
+    public CustomPreference(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public CustomPreference(Context context) {
+        super(context);
+    }
+
+    @Override
+    protected void onBindView(View view) {
+        super.onBindView(view);
+        TextView titleView = (TextView) view.findViewById(android.R.id.title);
+        if (titleColor != -1) {
+            titleView.setTextColor(titleColor);
+        }
+
+        TextView summaryView = (TextView) view.findViewById(android.R.id.summary);
+        if (summaryColor != -1) {
+            summaryView.setTextColor(summaryColor);
+        }
+    }
+}

--- a/sample/src/main/java/io/sweers/barber/sample/testing/TestPreferencesActivity.java
+++ b/sample/src/main/java/io/sweers/barber/sample/testing/TestPreferencesActivity.java
@@ -1,0 +1,23 @@
+package io.sweers.barber.sample.testing;
+
+import android.os.Bundle;
+import android.preference.PreferenceActivity;
+
+import io.sweers.barber.sample.R;
+
+/**
+ * Preferences can be styled too!
+ */
+@SuppressWarnings("deprecation")
+public class TestPreferencesActivity extends PreferenceActivity {
+
+    public CustomPreference customPreference;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        addPreferencesFromResource(R.xml.test_prefs);
+        customPreference = (CustomPreference) findPreference("custom_pref");
+    }
+}

--- a/sample/src/main/res/values/attrs.xml
+++ b/sample/src/main/res/values/attrs.xml
@@ -41,4 +41,9 @@
         <attr name="requiredString" format="string" />
     </declare-styleable>
 
+    <declare-styleable name="TestPreference">
+        <attr name="prefTitleColor" format="color" />
+        <attr name="prefSummaryColor" format="color" />
+    </declare-styleable>
+
 </resources>

--- a/sample/src/main/res/xml/test_prefs.xml
+++ b/sample/src/main/res/xml/test_prefs.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:barber="http://schemas.android.com/apk/res-auto">
+
+    <io.sweers.barber.sample.testing.CustomPreference
+        android:key="custom_pref"
+        android:title="Here's a cool title"
+        android:summary="And here's a nifty summary"
+        barber:prefTitleColor="@android:color/holo_red_dark"
+        barber:prefSummaryColor="@android:color/holo_blue_dark"
+        />
+
+</PreferenceScreen>


### PR DESCRIPTION
This fixes #8 by removing the hard `View` requirement for the passed in target. This includes a new test for verifying this in custom preferences, which was an interesting lesson in instrumentation tests
