### PR TITLE
Defaults support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ public class BarberView extends FrameLayout {
     @StyledAttr(R.styleable.BarberView_stripeCount)
     public int stripeCount;
 
-    @StyledAttr(R.styleable.BarberView_animated)
+    @StyledAttr(value = R.styleable.BarberView_animated, defaultValue = R.bool.animated_default)
     public boolean isAnimated;
 
     public BarberView(Context context) {
@@ -109,6 +109,15 @@ public float testFractionBase;
 
 See the [Kind enum](https://github.com/hzsweers/barber/blob/master/api/src/main/java/io/sweers/barber/Kind.java) for a full list of supported types.
 
+*What about default values?*
+
+You're in luck! `@StyledAttr` now supports specifying resource IDs for default values.
+
+```java
+@StyledAttr(value = R.styleable.BarberView_animated, defaultValue = R.bool.animated_default)
+public boolean isAnimated;
+```
+
 #### AndroidAttr
 
 If you want to retrieve the value of an Android attribute, you can use `@AndroidAttr` to retrieve its value
@@ -118,7 +127,7 @@ If you want to retrieve the value of an Android attribute, you can use `@Android
 public boolean textAllCaps;
 ```
 
-Like `StyledAttr`, the default behavior is to return the type of the field/param. These are also subject to the same approach as `@StyledAttr` regarding special return types. See the [AttrSetKind enum](https://github.com/hzsweers/barber/blob/master/api/src/main/java/io/sweers/barber/AttrSetKind.java) for a full list of supported types.
+Like `StyledAttr`, the normal behavior is to return the type of the field/param. These are also subject to the same approach as `@StyledAttr` regarding special return types. See the [AttrSetKind enum](https://github.com/hzsweers/barber/blob/master/api/src/main/java/io/sweers/barber/AttrSetKind.java) for a full list of supported types.
 
 ```java
 @AndroidAttr(value = "textColor", kind = AttrSetKind.RESOURCE)
@@ -129,7 +138,7 @@ Right now it's just limited to the API of `AttributeSet`, but I may look into ad
 
 Required attributes
 -------------------
-If you want to require an attribute to be specified (beyond just checking if the value is still the default), you can use the `@Required` annotation as well.
+If you want to require an attribute to be specified, you can use the `@Required` annotation as well.
 
 ```java
 @Required
@@ -142,10 +151,6 @@ Now, if a view is inflated without specifying this attribute, its generated `$$B
 `Missing required attribute 'requiredString' while styling 'io.sweers.barber.sample.testing.RequiredTestView'`
 
 **NOTE:** Due to how `AttributeSet`'s interface works, `@Required` is not compatible with `@AndroidAttr` annotations.
-
-A word about default values
----------------------------
-Due to limitations of how annotations work, you cannot specify a default value in the annotation. For `@StyledAttr` fields however, Barber *will not* override any existing values on a field if there is no value at that index. So if you want a default value, initialize the field to it. This is because we can check if the `TypedArray` contains a value without retrieving it. Unfortunately, annotated setters and fields annotated with `@AndroidAttr` are out of luck here.
 
 Installation
 ------------

--- a/api/src/main/java/io/sweers/barber/Barber.java
+++ b/api/src/main/java/io/sweers/barber/Barber.java
@@ -1,7 +1,9 @@
 package io.sweers.barber;
 
+import android.content.res.Resources;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.util.TypedValue;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -87,5 +89,12 @@ public class Barber {
         @SuppressWarnings("unused")
         String ANDROID_ATTR_NAMESPACE = "http://schemas.android.com/apk/res/android";
         void style(final T target, final AttributeSet set, final int[] attrs, final int defStyleAttr, final int defStyleRes);
+    }
+
+    @SuppressWarnings("unused")
+    public static float resolveFloatResource(Resources res, int resId) {
+        TypedValue outValue = new TypedValue();
+        res.getValue(resId, outValue, true);
+        return outValue.getFloat();
     }
 }

--- a/api/src/main/java/io/sweers/barber/StyledAttr.java
+++ b/api/src/main/java/io/sweers/barber/StyledAttr.java
@@ -18,6 +18,8 @@ public @interface StyledAttr {
     // such as color ints or fraction floats
     Kind kind() default Kind.STANDARD;
 
+    int defaultValue() default -1;
+
     // Fraction base and parent base specifiers
     int base() default 1;
     int pbase() default 1;

--- a/sample/src/androidTest/java/io/sweers/barber/sample/BarberTest.java
+++ b/sample/src/androidTest/java/io/sweers/barber/sample/BarberTest.java
@@ -11,6 +11,7 @@ import android.view.ViewGroup;
 import java.util.Arrays;
 
 import io.sweers.barber.sample.testing.ChildTestView;
+import io.sweers.barber.sample.testing.DefaultsTestView;
 import io.sweers.barber.sample.testing.GrandChildTestView;
 import io.sweers.barber.sample.testing.TestTextView;
 import io.sweers.barber.sample.testing.TestView;
@@ -21,6 +22,7 @@ public class BarberTest extends AndroidTestCase {
     private ChildTestView childTestView;
     private GrandChildTestView grandChildTestView;
     private TestTextView testTextView;
+    private DefaultsTestView defaultsTestView;
     private Resources res;
 
     @Override
@@ -30,101 +32,126 @@ public class BarberTest extends AndroidTestCase {
         childTestView = (ChildTestView) View.inflate(getContext(), R.layout.child_test_view, null);
         grandChildTestView = (GrandChildTestView) View.inflate(getContext(), R.layout.grand_child_test_view, null);
         testTextView = (TestTextView) View.inflate(getContext(), R.layout.test_textview, null);
+        defaultsTestView = (DefaultsTestView) View.inflate(getContext(), R.layout.defaults_test_view, null);
         res = getContext().getResources();
     }
 
     @SmallTest
     public void testBoolean() {
         assertTrue(testView.testBoolean);
+        assertTrue(defaultsTestView.testBoolean);
     }
 
     @SmallTest
     public void testInt() {
         assertEquals(3, testView.testInt);
+        assertEquals(3, defaultsTestView.testInt);
     }
 
     @SmallTest
     public void testInteger() {
         assertEquals(12, testView.testInteger);
+        assertEquals(3, defaultsTestView.testInteger);
     }
 
     @SmallTest
     public void testColor() {
         assertEquals(res.getColor(android.R.color.holo_red_dark), testView.testColor);
+        assertEquals(res.getColor(android.R.color.holo_red_dark), defaultsTestView.testColor);
     }
 
     @SmallTest
     public void testFloat() {
         assertEquals(0.75f, testView.testFloat);
+        assertEquals(0.75f, defaultsTestView.testFloat);
     }
 
     @SmallTest
     public void testCharSequence() {
         assertNotNull(testView.testCharSequence);
         assertEquals("charsequence", testView.testCharSequence);
+        assertNotNull(defaultsTestView.testCharSequence);
+        assertEquals("charsequence", defaultsTestView.testCharSequence);
     }
 
     @SmallTest
     public void testString() {
         assertNotNull(testView.testString);
         assertEquals("this is a string", testView.testString);
+        assertNotNull(defaultsTestView.testString);
+        assertEquals("this is a string", defaultsTestView.testString);
     }
 
     @SmallTest
     public void testTextArray() {
         assertNotNull(testView.testTextArray);
         assertTrue(Arrays.deepEquals(testView.testTextArray, res.getTextArray(R.array.buzzwords)));
+        assertNotNull(defaultsTestView.testTextArray);
+        assertTrue(Arrays.deepEquals(defaultsTestView.testTextArray, res.getTextArray(R.array.buzzwords)));
     }
 
     @SmallTest
     public void testColorStateList() {
-        assertNotNull(testView.testColorStateList);
-        assertTrue(testView.testColorStateList.isStateful());
-
         int defaultColor = res.getColor(android.R.color.holo_blue_bright);
         int pressedColor = res.getColor(android.R.color.holo_blue_dark);
         int[] pressedState = {android.R.attr.state_pressed};
         int[] defaultState = {};
 
+        assertNotNull(testView.testColorStateList);
+        assertTrue(testView.testColorStateList.isStateful());
         assertEquals(pressedColor, testView.testColorStateList.getColorForState(pressedState, defaultColor));
         assertEquals(defaultColor, testView.testColorStateList.getColorForState(defaultState, defaultColor));
+
+        assertNotNull(defaultsTestView.testColorStateList);
+        assertTrue(defaultsTestView.testColorStateList.isStateful());
+        assertEquals(pressedColor, defaultsTestView.testColorStateList.getColorForState(pressedState, defaultColor));
+        assertEquals(defaultColor, defaultsTestView.testColorStateList.getColorForState(defaultState, defaultColor));
     }
 
     @SmallTest
     public void testDrawable() {
         assertNotNull(testView.testDrawable);
+        assertNotNull(defaultsTestView.testDrawable);
     }
 
     @SmallTest
     public void testFraction() {
         assertEquals(res.getFraction(R.fraction.fraction, 2, 2), testView.testFractionBase);
         assertEquals(res.getFraction(R.fraction.parent_fraction, 2, 2), testView.testFracionPBase);
+        assertEquals(res.getFraction(R.fraction.fraction, 2, 2), defaultsTestView.testFractionBase);
+        assertEquals(res.getFraction(R.fraction.parent_fraction, 2, 2), defaultsTestView.testFracionPBase);
     }
 
     @SmallTest
     public void testDimension() {
-        assertEquals(res.getDimension(R.dimen.test_dimen), testView.testDimension);
+        assertEquals(res.getDimension(R.dimen.test_dimen), testView.testDimension, 0.01f);
+        assertEquals(res.getDimension(R.dimen.test_dimen), defaultsTestView.testDimension, 0.01f);
     }
 
     @SmallTest
     public void testDimensionPixelSize() {
         assertEquals(res.getDimensionPixelSize(R.dimen.test_dimen), testView.testDimensionPixelSize);
+        assertEquals(res.getDimensionPixelSize(R.dimen.test_dimen), defaultsTestView.testDimensionPixelSize);
     }
 
     @SmallTest
     public void testDimensionPixelOffset() {
         assertEquals(res.getDimensionPixelOffset(R.dimen.test_dimen), testView.testDimensionPixelOffset);
+        assertEquals(res.getDimensionPixelOffset(R.dimen.test_dimen), defaultsTestView.testDimensionPixelOffset);
     }
 
     @SmallTest
     public void testResId() {
         assertEquals(R.array.buzzwords, testView.testResId);
+        assertEquals(R.array.buzzwords, defaultsTestView.testResId);
     }
 
     @SmallTest
     public void testNonResString() {
         assertEquals("Hello", testView.testNonResString1);
         assertNull(testView.testNonResString2);
+        assertEquals("Hello", defaultsTestView.testNonResString1);
+        assertEquals("Hello", defaultsTestView.testNonResString2);
     }
 
     @SmallTest

--- a/sample/src/main/java/io/sweers/barber/sample/BarberView.java
+++ b/sample/src/main/java/io/sweers/barber/sample/BarberView.java
@@ -20,7 +20,7 @@ import io.sweers.barber.StyledAttr;
  */
 public class BarberView extends FrameLayout {
 
-    @StyledAttr(value = R.styleable.BarberView_stripeColor, kind = Kind.COLOR)
+    @StyledAttr(value = R.styleable.BarberView_stripeColor, kind = Kind.COLOR, defaultValue = R.color.material_blue_grey_800)
     int stripeColor = Color.BLUE;
 
     @StyledAttr(R.styleable.BarberView_stripeCount)

--- a/sample/src/main/java/io/sweers/barber/sample/BarberView.java
+++ b/sample/src/main/java/io/sweers/barber/sample/BarberView.java
@@ -20,8 +20,8 @@ import io.sweers.barber.StyledAttr;
  */
 public class BarberView extends FrameLayout {
 
-    @StyledAttr(value = R.styleable.BarberView_stripeColor, kind = Kind.COLOR, defaultValue = R.color.material_blue_grey_800)
-    int stripeColor = Color.BLUE;
+    @StyledAttr(value = R.styleable.BarberView_stripeColor, kind = Kind.COLOR, defaultValue = android.R.color.holo_red_dark)
+    int stripeColor;
 
     @StyledAttr(R.styleable.BarberView_stripeCount)
     int stripeCount = 3;

--- a/sample/src/main/java/io/sweers/barber/sample/MainActivity.java
+++ b/sample/src/main/java/io/sweers/barber/sample/MainActivity.java
@@ -4,13 +4,13 @@ import android.app.AlertDialog;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 import android.text.Html;
 import android.view.Menu;
 import android.view.MenuItem;
 
 
-public class MainActivity extends ActionBarActivity {
+public class MainActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/sample/src/main/java/io/sweers/barber/sample/testing/DefaultsTestView.java
+++ b/sample/src/main/java/io/sweers/barber/sample/testing/DefaultsTestView.java
@@ -1,0 +1,133 @@
+package io.sweers.barber.sample.testing;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.util.AttributeSet;
+import android.view.View;
+
+import io.sweers.barber.Barber;
+import io.sweers.barber.Kind;
+import io.sweers.barber.StyledAttr;
+import io.sweers.barber.sample.R;
+
+/**
+ * View for testing defaults
+ */
+public class DefaultsTestView extends View {
+
+    @StyledAttr(value = R.styleable.TestView_testBoolean, defaultValue = R.bool.test_default_bool)
+    public boolean testBoolean = false;
+
+    @StyledAttr(value = R.styleable.TestView_testInt, defaultValue = R.integer.test_default_int)
+    public int testInt = -1;
+
+    @StyledAttr(value = R.styleable.TestView_testInteger, kind = Kind.INTEGER, defaultValue = R.integer.test_default_int)
+    public int testInteger = -1;
+
+    @StyledAttr(value = R.styleable.TestView_testColor, kind = Kind.COLOR, defaultValue = android.R.color.holo_red_dark)
+    public int testColor;
+
+    @StyledAttr(value = R.styleable.TestView_testCharSequence, defaultValue = R.string.test_default_charseq)
+    public CharSequence testCharSequence;
+
+    @StyledAttr(value = R.styleable.TestView_testString, defaultValue = R.string.test_default_string)
+    public String testString;
+
+    @StyledAttr(value = R.styleable.TestView_testTextArray, defaultValue = R.array.buzzwords)
+    public CharSequence[] testTextArray;
+
+    @StyledAttr(value = R.styleable.TestView_testColorStateList, defaultValue = R.color.button_selector)
+    public ColorStateList testColorStateList;
+
+    @StyledAttr(value = R.styleable.TestView_testDrawable, defaultValue = R.drawable.ic_action_refresh)
+    public Drawable testDrawable;
+
+    @StyledAttr(
+            value = R.styleable.TestView_testFractionBase,
+            kind = Kind.FRACTION,
+            base = 2,
+            pbase = 2,
+            defaultValue = R.fraction.fraction
+    )
+    public float testFractionBase;
+
+    @StyledAttr(
+            value = R.styleable.TestView_testFractionPBase,
+            kind = Kind.FRACTION,
+            base = 2,
+            pbase = 2,
+            defaultValue = R.fraction.parent_fraction
+    )
+    public float testFracionPBase;
+
+    @StyledAttr(
+            value = R.styleable.TestView_testDimension,
+            kind = Kind.DIMEN,
+            defaultValue = R.dimen.test_dimen
+    )
+    public float testDimension;
+
+    @StyledAttr(
+            value = R.styleable.TestView_testDimensionPixelSize,
+            kind = Kind.DIMEN_PIXEL_SIZE,
+            defaultValue = R.dimen.test_dimen
+    )
+    public int testDimensionPixelSize;
+
+    @StyledAttr(
+            value = R.styleable.TestView_testDimensionPixelOffset,
+            kind = Kind.DIMEN_PIXEL_OFFSET,
+            defaultValue = R.dimen.test_dimen
+    )
+    public int testDimensionPixelOffset;
+
+    @StyledAttr(
+            value = R.styleable.TestView_testResourceId,
+            kind = Kind.RES_ID,
+            defaultValue = R.array.buzzwords
+    )
+    public int testResId;
+
+    @StyledAttr(
+            value = R.styleable.TestView_testNonResString1,
+            kind = Kind.NON_RES_STRING,
+            defaultValue = R.string.testStringRes
+    )
+    public String testNonResString1;
+
+    @StyledAttr(
+            value = R.styleable.TestView_testNonResString2,
+            kind = Kind.NON_RES_STRING,
+            defaultValue = R.string.testStringRes
+    )
+    public String testNonResString2;
+
+    public float testFloat;
+
+    public DefaultsTestView(Context context) {
+        super(context);
+    }
+
+    public DefaultsTestView(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public DefaultsTestView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        Barber.style(this, attrs, R.styleable.TestView, defStyleAttr);
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public DefaultsTestView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        Barber.style(this, attrs, R.styleable.TestView, defStyleAttr, defStyleRes);
+    }
+
+    @StyledAttr(value = R.styleable.TestView_testFloat, defaultValue = R.dimen.test_default_float)
+    public void setTestFloat(float test) {
+        this.testFloat = test;
+    }
+}

--- a/sample/src/main/res/layout/defaults_test_view.xml
+++ b/sample/src/main/res/layout/defaults_test_view.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<io.sweers.barber.sample.testing.DefaultsTestView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:barber="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    />

--- a/sample/src/main/res/values/bools.xml
+++ b/sample/src/main/res/values/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="test_default_bool">true</bool>
+</resources>

--- a/sample/src/main/res/values/dimens.xml
+++ b/sample/src/main/res/values/dimens.xml
@@ -4,4 +4,5 @@
     <dimen name="activity_vertical_margin">16dp</dimen>
 
     <dimen name="test_dimen">16dp</dimen>
+    <item name="test_default_float" format="float" type="dimen">0.75</item>
 </resources>

--- a/sample/src/main/res/values/integers.xml
+++ b/sample/src/main/res/values/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="test_default_int">3</integer>
+</resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -10,4 +10,6 @@
         <a href=\'https://github.com/hzsweers\'>GitHub</a>&nbsp;&nbsp;
         <a href=\'https://www.linkedin.com/profile/view?id=126301011\'>LinkedIn</a>
     ]]></string>
+    <string name="test_default_charseq">charsequence</string>
+    <string name="test_default_string">this is a string</string>
 </resources>

--- a/sample/src/test/java/io/sweers/barber/sample/BarberTest.java
+++ b/sample/src/test/java/io/sweers/barber/sample/BarberTest.java
@@ -18,6 +18,7 @@ import org.robolectric.annotation.Config;
 import java.util.Arrays;
 
 import io.sweers.barber.sample.testing.ChildTestView;
+import io.sweers.barber.sample.testing.DefaultsTestView;
 import io.sweers.barber.sample.testing.GrandChildTestView;
 import io.sweers.barber.sample.testing.TestTextView;
 import io.sweers.barber.sample.testing.TestView;
@@ -31,6 +32,7 @@ public class BarberTest {
     private ChildTestView childTestView;
     private GrandChildTestView grandChildTestView;
     private TestTextView testTextView;
+    private DefaultsTestView defaultsTestView;
     private Resources res;
 
     @Before
@@ -40,95 +42,118 @@ public class BarberTest {
         childTestView = (ChildTestView) View.inflate(context, R.layout.child_test_view, null);
         grandChildTestView = (GrandChildTestView) View.inflate(context, R.layout.grand_child_test_view, null);
         testTextView = (TestTextView) View.inflate(context, R.layout.test_textview, null);
+        defaultsTestView = (DefaultsTestView) View.inflate(context, R.layout.defaults_test_view, null);
         res = context.getResources();
     }
 
     @Test
     public void testBoolean() {
         Assert.assertTrue(testView.testBoolean);
+        Assert.assertTrue(defaultsTestView.testBoolean);
     }
 
     @Test
     public void testInt() {
         Assert.assertEquals(3, testView.testInt);
+        Assert.assertEquals(3, defaultsTestView.testInt);
     }
 
     @Test
     public void testInteger() {
         Assert.assertEquals(12, testView.testInteger);
+        Assert.assertEquals(3, defaultsTestView.testInteger);
     }
 
     @Test
     public void testColor() {
         Assert.assertEquals(res.getColor(android.R.color.holo_red_dark), testView.testColor);
+        Assert.assertEquals(res.getColor(android.R.color.holo_red_dark), defaultsTestView.testColor);
     }
 
     @Test
     public void testFloat() {
         Assert.assertEquals(0.75f, testView.testFloat, 0.01f);
+        Assert.assertEquals(0.75f, defaultsTestView.testFloat, 0.01f);
     }
 
     @Test
     public void testCharSequence() {
         Assert.assertNotNull(testView.testCharSequence);
         Assert.assertEquals("charsequence", testView.testCharSequence);
+        Assert.assertNotNull(defaultsTestView.testCharSequence);
+        Assert.assertEquals("charsequence", defaultsTestView.testCharSequence);
     }
 
     @Test
     public void testString() {
         Assert.assertNotNull(testView.testString);
         Assert.assertEquals("this is a string", testView.testString);
+        Assert.assertNotNull(defaultsTestView.testString);
+        Assert.assertEquals("this is a string", defaultsTestView.testString);
     }
 
     @Test
     public void testTextArray() {
         Assert.assertNotNull(testView.testTextArray);
         Assert.assertTrue(Arrays.deepEquals(testView.testTextArray, res.getTextArray(R.array.buzzwords)));
+        Assert.assertNotNull(defaultsTestView.testTextArray);
+        Assert.assertTrue(Arrays.deepEquals(defaultsTestView.testTextArray, res.getTextArray(R.array.buzzwords)));
     }
 
     @Test
     public void testColorStateList() {
-        Assert.assertNotNull(testView.testColorStateList);
-        Assert.assertTrue(testView.testColorStateList.isStateful());
-
         int defaultColor = res.getColor(android.R.color.holo_blue_bright);
         int pressedColor = res.getColor(android.R.color.holo_blue_dark);
         int[] pressedState = {android.R.attr.state_pressed};
         int[] defaultState = {};
 
+        Assert.assertNotNull(testView.testColorStateList);
+        Assert.assertTrue(testView.testColorStateList.isStateful());
         Assert.assertEquals(pressedColor, testView.testColorStateList.getColorForState(pressedState, defaultColor));
         Assert.assertEquals(defaultColor, testView.testColorStateList.getColorForState(defaultState, defaultColor));
+
+        Assert.assertNotNull(defaultsTestView.testColorStateList);
+        Assert.assertTrue(defaultsTestView.testColorStateList.isStateful());
+        Assert.assertEquals(pressedColor, defaultsTestView.testColorStateList.getColorForState(pressedState, defaultColor));
+        Assert.assertEquals(defaultColor, defaultsTestView.testColorStateList.getColorForState(defaultState, defaultColor));
     }
 
     @Test
     public void testDrawable() {
         Assert.assertNotNull(testView.testDrawable);
+        Assert.assertNotNull(defaultsTestView.testDrawable);
     }
 
     @Test
     public void testFraction() {
         Assert.assertEquals(res.getFraction(R.fraction.fraction, 2, 2), testView.testFractionBase, 0.1f);
         Assert.assertEquals(res.getFraction(R.fraction.parent_fraction, 2, 2), testView.testFracionPBase, 0.1f);
+        Assert.assertEquals(res.getFraction(R.fraction.fraction, 2, 2), defaultsTestView.testFractionBase, 0.1f);
+        Assert.assertEquals(res.getFraction(R.fraction.parent_fraction, 2, 2), defaultsTestView.testFracionPBase, 0.1f);
     }
 
     @Test
     public void testDimension() {
         Assert.assertEquals(res.getDimension(R.dimen.test_dimen), testView.testDimension, 0.01f);
+        Assert.assertEquals(res.getDimension(R.dimen.test_dimen), defaultsTestView.testDimension, 0.01f);
     }
 
     @Test
     public void testDimensionPixelSize() {
         Assert.assertEquals(res.getDimensionPixelSize(R.dimen.test_dimen), testView.testDimensionPixelSize);
+        Assert.assertEquals(res.getDimensionPixelSize(R.dimen.test_dimen), defaultsTestView.testDimensionPixelSize);
     }
 
     @Test
     public void testDimensionPixelOffset() {
         Assert.assertEquals(res.getDimensionPixelOffset(R.dimen.test_dimen), testView.testDimensionPixelOffset);
+        Assert.assertEquals(res.getDimensionPixelOffset(R.dimen.test_dimen), defaultsTestView.testDimensionPixelOffset);
     }
 
     @Test
     public void testResId() {
         Assert.assertEquals(R.array.buzzwords, testView.testResId);
+        Assert.assertEquals(R.array.buzzwords, defaultsTestView.testResId);
     }
 
     // These are borked by Robolectric right now.
@@ -137,6 +162,8 @@ public class BarberTest {
     public void testNonResString() {
 //        Assert.assertEquals("Hello", testView.testNonResString1);
 //        Assert.assertNull(testView.testNonResString2);
+//        Assert.assertEquals("Hello", defaultsTestView.testNonResString1);
+//        Assert.assertEquals("Hello", defaultsTestView.testNonResString2);
     }
 
     @Test


### PR DESCRIPTION
Resolves #16 

This allows for the use of a new `defaultValue` option in `StyledAttr` annotations, where you can set a resource ID to use as a default.

The generated code will still check `Required` if the annotation is there. It will not resolve the default value unless there is no resource at that index (that is, it won't unnecessarily resolve it just to pass it into the second param of many of the typedarray getters).

`AndroidAttr` doesn't support defaults, because it doesn't really make sense to. It would really have to force the user to only use it on setters to be practical.
